### PR TITLE
chore: update kyve precompile to new response schema

### DIFF
--- a/wvm-apps/wvm-exexed/crates/precompiles/src/inner/kyve_precompile.rs
+++ b/wvm-apps/wvm-exexed/crates/precompiles/src/inner/kyve_precompile.rs
@@ -65,7 +65,7 @@ fn kyve_read(input: &Bytes, gas_limit: u64) -> PrecompileResult {
         match req {
             Ok(resp) => match resp.json::<serde_json::Value>().await {
                 Ok(json_val) => {
-                    let main_val = json_val.get("value").and_then(|v| v.get("value")).unwrap();
+                    let main_val = json_val.get("value").unwrap();
 
                     let slot = main_val.get("slot").and_then(|s| s.as_u64()).unwrap().to_string();
 


### PR DESCRIPTION
This PR updates the KYVE precompile to the new response schema from the KYVE Trustless API.

Schema is now the following:

```ts
{
    "key": string;
    "value": {
        "slot": number;
        "blobs": Blob[];
    }
}
```

See [Trustless API Docs](https://data.services.kyve.network) for more details.